### PR TITLE
Display last modified time on authored pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -53,6 +53,10 @@ export default defineConfig({
     starlight({
       title: "kiara",
       customCss: ["./src/styles/custom.css"],
+      components: {
+        // override the default title component, to add in last modified time
+        PageTitle: './src/components/Title.astro',
+      },
       social: {
         github: "https://github.com/DHARPA-project/kiara-website",
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.18",
         "astro": "^4.2.1",
+        "dayjs": "^1.11.10",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "semver-sort": "^1.0.0",
@@ -60,11 +61,11 @@
       }
     },
     "node_modules/@astrojs/check": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.5.4.tgz",
-      "integrity": "sha512-BFClaLEuRzpfF9wrmh9KDS5gmRHGhkVN7qvm6tWPBvUxOADXiNz+hzrYFvZVqXTXhHjS0Ern1g3yHifgu0zsmw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.5.5.tgz",
+      "integrity": "sha512-05LjyUB14Cv2mkLNqY4r2igI2eu0bq/HcKCfFNIoBPLyNW7VUDr9tciD9VJXXT3s0e6JHneIs6bQW5ipjmaRcw==",
       "dependencies": {
-        "@astrojs/language-server": "^2.7.4",
+        "@astrojs/language-server": "^2.7.5",
         "chokidar": "^3.5.3",
         "fast-glob": "^3.3.1",
         "kleur": "^4.1.5",
@@ -96,9 +97,9 @@
       }
     },
     "node_modules/@astrojs/compiler": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.5.3.tgz",
-      "integrity": "sha512-jzj01BRv/fmo+9Mr2FhocywGzEYiyiP2GVHje1ziGNU6c97kwhYGsnvwMkHrncAy9T9Vi54cjaMK7UE4ClX4vA=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.6.0.tgz",
+      "integrity": "sha512-c74k8iGHL3DzkosSJ0tGcHIEBEiIfBhr7eadSaPyvWlVKaieDVzVs8OW1tnRSQyBsfMc8DZQ4RcN2KAcESD8UQ=="
     },
     "node_modules/@astrojs/internal-helpers": {
       "version": "0.2.1",
@@ -106,9 +107,9 @@
       "integrity": "sha512-06DD2ZnItMwUnH81LBLco3tWjcZ1lGU9rLCCBaeUCGYe9cI0wKyY2W3kDyoW1I6GmcWgt1fu+D1CTvz+FIKf8A=="
     },
     "node_modules/@astrojs/language-server": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.7.4.tgz",
-      "integrity": "sha512-U317ZKx5VXg2Sy6iPgYOliOZ10Ji/eo8MGFCry2/yT+rYTfb81HbrSWUu9nsZzpFK66So5aprQutRWWM/m7mPQ==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.7.5.tgz",
+      "integrity": "sha512-iMfZ3UaqTgIL+z/eUDOppRa1bGUAteWRihbWq5mGAgvr/hu384ZXUKJcqV3BBux0MBsRXwjxzrC2dJu9IpAaoA==",
       "dependencies": {
         "@astrojs/compiler": "^2.4.0",
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -118,12 +119,12 @@
         "@volar/language-service": "~2.0.4",
         "@volar/typescript": "~2.0.4",
         "fast-glob": "^3.2.12",
-        "volar-service-css": "0.0.29",
-        "volar-service-emmet": "0.0.29",
-        "volar-service-html": "0.0.29",
-        "volar-service-prettier": "0.0.29",
-        "volar-service-typescript": "0.0.29",
-        "volar-service-typescript-twoslash-queries": "0.0.29",
+        "volar-service-css": "0.0.30",
+        "volar-service-emmet": "0.0.30",
+        "volar-service-html": "0.0.30",
+        "volar-service-prettier": "0.0.30",
+        "volar-service-typescript": "0.0.30",
+        "volar-service-typescript-twoslash-queries": "0.0.30",
         "vscode-html-languageservice": "^5.1.2",
         "vscode-uri": "^3.0.8"
       },
@@ -244,18 +245,18 @@
       }
     },
     "node_modules/@astrojs/sitemap": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.0.5.tgz",
-      "integrity": "sha512-60eLzNjMza3ABypiQPUC6ElOSZNZeY5CwSwgJ03hfeonl+Db9x12CCzBFdTw7A5Mq+O54xEZVUrR0tB+yWgX8w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.1.1.tgz",
+      "integrity": "sha512-qPgdBIcDUaea98mTtLfi5z9oXZpzSjEn/kes70/Ex8FOZZ+DIHVKRYOLOtvy8p+FTXr/9oc7BjmIbTYmYLLJVg==",
       "dependencies": {
         "sitemap": "^7.1.1",
         "zod": "^3.22.4"
       }
     },
     "node_modules/@astrojs/starlight": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.19.0.tgz",
-      "integrity": "sha512-izNZLs99d4AAoN5eV6Ek71SVKEAs8N/GjT+n9J0Q8q1Zgtk/qcv3KzuPXBZmiAbPl/9E2+BG8f4dpdoc+F4U3g==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/starlight/-/starlight-0.19.1.tgz",
+      "integrity": "sha512-HcrgWAdOJRVRhiOf4TySzpCek/6N56jq5Iz0ahDTE5Fv2tHHA2cLIRAOvVF+iPNVZa349hqv6QSCmzUHA2JK4Q==",
       "dependencies": {
         "@astrojs/mdx": "^2.1.1",
         "@astrojs/sitemap": "^3.0.5",
@@ -4445,9 +4446,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-4.4.0.tgz",
-      "integrity": "sha512-JAsMrm1Z6W4Iqg9Q7LW/6lCXrqa4jndEOlR/yu7NGNP0BrPwSM8i4+yzya6hxgsNvyyVK8ywthaNhFmqd8Z+cg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-4.4.3.tgz",
+      "integrity": "sha512-9Ih+2mJv+i3XgGfU8m9evkNU7NEQWvOhqGsskrCwKmltuTtLol2hPw+eIfE49Yfktzfj5qLC6ZGkPxCJu5gkhA==",
       "dependencies": {
         "@astrojs/compiler": "^2.5.3",
         "@astrojs/internal-helpers": "0.2.1",
@@ -4501,7 +4502,6 @@
         "rehype": "^13.0.1",
         "resolve": "^1.22.4",
         "semver": "^7.5.4",
-        "server-destroy": "^1.0.1",
         "shikiji": "^0.9.19",
         "shikiji-core": "^0.9.19",
         "string-width": "^7.0.0",
@@ -5118,9 +5118,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001588",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001588.tgz",
-      "integrity": "sha512-+hVY9jE44uKLkH0SrUTqxjxqNTOWHsbnQDIKjwkZ3lNTzUUVdBLBGXtj/q5Mp5u98r3droaZAewQuEDzjQdZlQ==",
+      "version": "1.0.30001589",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001589.tgz",
+      "integrity": "sha512-vNQWS6kI+q6sBlHbh71IIeC+sRwK2N3EDySc/updIGhIee2x5z00J4c1242/5/d6EpEMdOnk/m+6tuk4/tcsqg==",
       "funding": [
         {
           "type": "opencollective",
@@ -5572,6 +5572,11 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
       "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA=="
     },
+    "node_modules/dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -5785,9 +5790,9 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.676",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.676.tgz",
-      "integrity": "sha512-uHt4FB8SeYdhcOsj2ix/C39S7sPSNFJpzShjxGOm1KdF4MHyGqGi389+T5cErsodsijojXilYaHIKKqJfqh7uQ=="
+      "version": "1.4.679",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.679.tgz",
+      "integrity": "sha512-NhQMsz5k0d6m9z3qAxnsOR/ebal4NAGsrNVRwcDo4Kc/zQ7KdsTKZUxZoygHcVRb0QDW3waEDIcE3isZ79RP6g=="
     },
     "node_modules/emery": {
       "version": "1.4.3",
@@ -7018,9 +7023,9 @@
       }
     },
     "node_modules/js-base64": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.6.tgz",
-      "integrity": "sha512-NPrWuHFxFUknr1KqJRDgUQPexQF0uIJWjeT+2KjEePhitQxQEx5EJBG1lVn5/hc8aLycTpXrDOgPQ6Zq+EDiTA=="
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -8443,9 +8448,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.5.tgz",
-      "integrity": "sha512-/Veqm+QKsyMY3kqi4faWplnY1u+VuKO3dD2binyPIybP31DRO29bPF+1mszgLnrR2KqSLceFLBNw0zmvDzN1QQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.6.tgz",
+      "integrity": "sha512-rRq0eMHoGZxlvaFOUdK1Ev83Bd1IgzzR+WJ3IbDJ7QOSdAxYjlurSPqFs9s4lJg29RT6nPwizFtJhQS6V5xgiA==",
       "funding": [
         {
           "type": "github",
@@ -8486,9 +8491,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.54.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.54.0.tgz",
-      "integrity": "sha512-p7eGEiQil0YUV3ItH4/tBb781L5impVmmx2E9FRKF7d18XXzp4PGT2tdYMFY6wQqgxD0IwNZOiSJ0/K0fSi/OA==",
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.55.0.tgz",
+      "integrity": "sha512-uPEjtyh2tFEvWYt4Jw7McOD5FPcHkcxm/tHZc5PWaDB3JYq0rGFUbgaAK+CT5pYpQddBfsZVWI08OwoRfdfbcQ==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -10457,9 +10462,9 @@
       ]
     },
     "node_modules/sanitize-html": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.11.0.tgz",
-      "integrity": "sha512-BG68EDHRaGKqlsNjJ2xUB7gpInPA8gVx/mvjO743hZaeMCZ2DwzW7xvsqZ+KNU4QKwj86HJ3uu2liISf2qBBUA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.12.1.tgz",
+      "integrity": "sha512-Plh+JAn0UVDpBRP/xEjsk+xDCoOvMBwQUf/K+/cBAVuTbtX8bj2VB7S1sL1dssVpykqp0/KPSesHrqXtokVBpA==",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
@@ -10567,11 +10572,6 @@
       "bin": {
         "semver": "bin/semver"
       }
-    },
-    "node_modules/server-destroy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
-      "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ=="
     },
     "node_modules/set-cookie-parser": {
       "version": "2.6.0",
@@ -11284,9 +11284,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/ultrahtml": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.5.2.tgz",
-      "integrity": "sha512-qh4mBffhlkiXwDAOxvSGxhL0QEQsTbnP9BozOK3OYPEGvPvdWzvAUaXNtUSMdNsKDtuyjEbyVUPFZ52SSLhLqw=="
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.5.3.tgz",
+      "integrity": "sha512-GykOvZwgDWZlTQMtp5jrD4BVL+gNn2NVlVafjcFUJ7taY20tqYdwdoWBFy6GBJsNTZe1GkGPkSl5knQAjtgceg=="
     },
     "node_modules/undici": {
       "version": "5.28.3",
@@ -11563,9 +11563,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.3.tgz",
-      "integrity": "sha512-UfmUD36DKkqhi/F75RrxvPpry+9+tTkrXfMNZD+SboZqBCMsxKtO52XeGzzuh7ioz+Eo/SYDBbdb0Z7vgcDJew==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.4.tgz",
+      "integrity": "sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==",
       "dependencies": {
         "esbuild": "^0.19.3",
         "postcss": "^8.4.35",
@@ -11630,9 +11630,9 @@
       }
     },
     "node_modules/volar-service-css": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.29.tgz",
-      "integrity": "sha512-2kNdgEYEiLeeer3wkagNBVDPa3Zj7mBDeM7D3iYmBXA0LCwd2tQL3eASzcDW9Gvac1g478UtptK468GxzUAEcA==",
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.30.tgz",
+      "integrity": "sha512-jui+1N0HBfjW43tRfhyZp0axhBee4997BRyX4os8xQm/7cjD2KjAuyz92nMIPRt1QDoG4/7uQT28xNhy0TPJTA==",
       "dependencies": {
         "vscode-css-languageservice": "^6.2.10",
         "vscode-uri": "^3.0.8"
@@ -11647,12 +11647,12 @@
       }
     },
     "node_modules/volar-service-emmet": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.29.tgz",
-      "integrity": "sha512-sXRMfQ970lpOQxUcKH9B4DqE7FCNhPy6V4m3gw+kgH17mADQ2rdL63b8osXFy5bnAMBcsXRhtJXJPmh/LgZXEw==",
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.30.tgz",
+      "integrity": "sha512-HEeIrmqQ/DTfuQDI9ER5+YReXXjE9f7W6MlBmn5biUuPyizVTGfuILN8pJhmYvmPHCA7qHhU7CJqwE9DAh9AJg==",
       "dependencies": {
         "@vscode/emmet-helper": "^2.9.2",
-        "volar-service-html": "0.0.29"
+        "volar-service-html": "0.0.30"
       },
       "peerDependencies": {
         "@volar/language-service": "~2.0.1"
@@ -11664,9 +11664,9 @@
       }
     },
     "node_modules/volar-service-html": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.29.tgz",
-      "integrity": "sha512-ctTSU46KCLxcaR53mAod2wBWSEIXGdXdejqHEDPSX33H5rA2X89zyYEpuk9BOVzIHG8G8rggVXCGnGaXxmYrCw==",
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.30.tgz",
+      "integrity": "sha512-wW3TEeRTeHv/3mC8Ik6T62SwewMWFungb8ydyEK/2GDHEntBEG/J9wtuh01/J0kYqPerhlT9zhdGB6PGYHAGuA==",
       "dependencies": {
         "vscode-html-languageservice": "^5.1.0",
         "vscode-uri": "^3.0.8"
@@ -11681,9 +11681,9 @@
       }
     },
     "node_modules/volar-service-prettier": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.29.tgz",
-      "integrity": "sha512-GxcDKfiVv3fc4XUtUOkQpX0QlFjWppRCVWIBp751gOKJwDex142xMlbTxP9la9tollbmj2O/tVUrqqLDGQ+Lsg==",
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.30.tgz",
+      "integrity": "sha512-Qdc5Zc0y4hJmJbpIQ52cSDjs0uvVug/e2nuL/XZWPJM6Cr5/3RjjoRVKtDQbKItFYlGk+JH+LSXvwQeD5TXZqg==",
       "dependencies": {
         "vscode-uri": "^3.0.8"
       },
@@ -11701,9 +11701,9 @@
       }
     },
     "node_modules/volar-service-typescript": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.29.tgz",
-      "integrity": "sha512-ssBhGT0Wrh670NRTrLoikzoRbszd72jIa02IKbrfI9QIIONvygOmIJ9jSqj4jxHEWz/KSCgCEhCyR7hEH80kGg==",
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.30.tgz",
+      "integrity": "sha512-jA8c0Mhy9rgAsrgtwocK95Smws1M2E0MxlQ/SVo/rmOGH32cX9UGgI0IENWKa3yagp/khfoemOIQDz/KNhI3zg==",
       "dependencies": {
         "path-browserify": "^1.0.1",
         "semver": "^7.5.4",
@@ -11723,9 +11723,9 @@
       }
     },
     "node_modules/volar-service-typescript-twoslash-queries": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.29.tgz",
-      "integrity": "sha512-hdI8ZO1Wc/I5+iwKKnOfXW7ktpBe0qLoXz5+8viS6aV9gycKSAKAs6sayLTATQZcZ1EAESUqTqGS/vJOUgZOsg==",
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.30.tgz",
+      "integrity": "sha512-ahj6woBxhkZu7icQR58x5TnUaS8ZRKn7a+UvY+andmiTWsOaSu85zj36+LPZgZQi1MG+BtjNwUjKoxtZiN51PA==",
       "peerDependencies": {
         "@volar/language-service": "~2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
     "astro": "^4.2.1",
+    "dayjs": "^1.11.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "semver-sort": "^1.0.0",

--- a/src/components/Title.astro
+++ b/src/components/Title.astro
@@ -1,0 +1,37 @@
+---
+import type { Props } from "@astrojs/starlight/props";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import { execSync } from "child_process";
+
+const { entry } = Astro.props;
+
+const isGenerated = Astro.props.slug.startsWith("plugins");
+let lastModified;
+
+if (!isGenerated) {
+  const filepath = `src/content/docs/${entry.id}`;
+  const result = execSync(`git log -1 --pretty="format:%cI" "${filepath}"`);
+  lastModified = result.toString();
+  dayjs.extend(utc);
+  lastModified = dayjs(lastModified).utc().format("YYYY-MM-DD");
+}
+
+---
+
+<h1 id="_top">{entry.data.title}</h1>
+{lastModified && <span>Last updated: {lastModified}</span>}
+
+<style>
+  span {
+    font-size: var(--sl-text-xs);
+  }
+
+  h1 {
+    margin-top: 1rem;
+    font-size: var(--sl-text-h1);
+    line-height: var(--sl-line-height-headings);
+    font-weight: 600;
+    color: var(--sl-color-white);
+  }
+</style>


### PR DESCRIPTION
Relevant to end users, I've added a little bit to the title of each page (that isn't in the autogenerated plugin docs section) to let readers know the last time that page was edited. I'm hoping this will help readers have a better idea if what they are reading is likely to be up to date, which has been a problem for our existing docs. You don't need to do anything different when writing, this gets updated automatically when the site builds. It looks like this:

![image](https://github.com/DHARPA-Project/kiara-website/assets/12828913/e870b80a-5e79-4455-ae18-fb0666f5e715)




Note for future me/other deployers - this uses the git history to work out when a file was last changed. If your build environment only does a shallow clone, all the pages will have been last modified today. You need to prefix your build command with `git fetch --unshallow &&` to get the full git history (or the equivalent for your build platform)